### PR TITLE
Fix config import

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -2,13 +2,15 @@
 
 # Django settings for django_agfk project.
 import os
-import config
 import sys
 
 SETTINGS_PATH = os.path.realpath(os.path.dirname(__file__))
 CLIENT_SERVER_PATH = SETTINGS_PATH
 AGFK_PATH = os.path.realpath(os.path.join(SETTINGS_PATH, '../'))
 
+sys.path.append(AGFK_PATH)
+
+import config
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),


### PR DESCRIPTION
When I execute `python server/manage.py runserver 8080` or `python server/manage.py loaddata dev_utils/graph_data.json`, I get this error:

```
Traceback (most recent call last):
  File "server/manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/mnt/code/repos/cloned/metacademy/meta_venv/lib/python2.7/site-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
    utility.execute()
  File "/mnt/code/repos/cloned/metacademy/meta_venv/lib/python2.7/site-packages/django/core/management/__init__.py", line 303, in execute
    settings.INSTALLED_APPS
  File "/mnt/code/repos/cloned/metacademy/meta_venv/lib/python2.7/site-packages/django/conf/__init__.py", line 48, in __getattr__
    self._setup(name)
  File "/mnt/code/repos/cloned/metacademy/meta_venv/lib/python2.7/site-packages/django/conf/__init__.py", line 44, in _setup
    self._wrapped = Settings(settings_module)
  File "/mnt/code/repos/cloned/metacademy/meta_venv/lib/python2.7/site-packages/django/conf/__init__.py", line 92, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/Cellar/python@2/2.7.15_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/mnt/code/repos/cloned/metacademy/metacademy-application/server/settings.py", line 8, in <module>
    import config
ImportError: No module named config
```

I saw a similar error message in #66.

This pull request fixes this error by adding the root directory of this repository to `sys.path`.