### PR TITLE
Replaced twitter.com with nitter.cc

### DIFF
--- a/server/static/html/about.html
+++ b/server/static/html/about.html
@@ -13,7 +13,7 @@
       About Metacademy
     </h1>
     <div class="social-icons">
-      <a href="https://twitter.com/meta_learning"><i class="icon-twitter"></i></a>
+      <a href="https://nitter.cc/meta_learning"><i class="icon-twitter"></i></a>
       <a href="https://github.com/metacademy/metacademy-application"><i class="icon-github-circled"></i></a>
     </div>
   </header>


### PR DESCRIPTION
Nitter is a more privacy-friendly frontend for Twitter